### PR TITLE
Add `auto` support for bedrock

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -566,6 +566,7 @@ pub enum ServiceTier {
 pub enum ServiceTierResponse {
     Scale,
     Default,
+    Auto, // AWS bedrock answer `auto` here
 }
 
 #[derive(Clone, Serialize, Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
Allows deserializing Service levels with value `auto` 

[Internal discussion](https://linear.app/meilisearch/issue/ENGPROD-2114/making-the-chat-route-compatible-with-aws-bedrock-openai-route)