### PR TITLE
Better error handling

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -418,8 +418,6 @@ impl<C: Config> Client<C> {
             .eventsource()
             .unwrap();
 
-        dbg!("HERE");
-
         stream(event_source).await
     }
 

--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -341,7 +341,12 @@ impl<C: Config> Client<C> {
                 let message: String = String::from_utf8_lossy(&bytes).into_owned();
                 tracing::warn!("Server error: {status} - {message}");
                 return Err(backoff::Error::Transient {
-                    err: OpenAIError::ApiError(ApiError { message, r#type: None, param: None, code: None }),
+                    err: OpenAIError::ApiError(ApiError {
+                        message,
+                        r#type: None,
+                        param: None,
+                        code: None,
+                    }),
                     retry_after: None,
                 });
             }
@@ -413,6 +418,8 @@ impl<C: Config> Client<C> {
             .eventsource()
             .unwrap();
 
+        dbg!("HERE");
+
         stream(event_source).await
     }
 
@@ -475,7 +482,7 @@ where
         while let Some(ev) = event_source.next().await {
             match ev {
                 Err(e) => {
-                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e.to_string()))) {
+                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e))) {
                         // rx dropped
                         break;
                     }
@@ -520,7 +527,7 @@ where
         while let Some(ev) = event_source.next().await {
             match ev {
                 Err(e) => {
-                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e.to_string()))) {
+                    if let Err(_e) = tx.send(Err(OpenAIError::StreamError(e))) {
                         // rx dropped
                         break;
                     }

--- a/async-openai/src/embedding.rs
+++ b/async-openai/src/embedding.rs
@@ -64,7 +64,6 @@ impl<'c, C: Config> Embeddings<'c, C> {
 
 #[cfg(test)]
 mod tests {
-    use crate::error::OpenAIError;
     use crate::types::{CreateEmbeddingResponse, Embedding, EncodingFormat};
     use crate::{types::CreateEmbeddingRequestArgs, Client};
 

--- a/async-openai/src/error.rs
+++ b/async-openai/src/error.rs
@@ -20,7 +20,7 @@ pub enum OpenAIError {
     FileReadError(String),
     /// Error on SSE streaming
     #[error("stream failed: {0}")]
-    StreamError(String),
+    StreamError(reqwest_eventsource::Error),
     /// Error from client side validation
     /// or when builder fails to build request before making API call
     #[error("invalid args: {0}")]

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -185,3 +185,6 @@ pub use users::Users;
 pub use vector_store_file_batches::VectorStoreFileBatches;
 pub use vector_store_files::VectorStoreFiles;
 pub use vector_stores::VectorStores;
+
+// re-exports
+pub use reqwest_eventsource;

--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -393,7 +393,7 @@ pub struct ChatCompletionMessageToolCall {
     /// The ID of the tool call.
     pub id: String,
     /// The type of the tool. Currently, only `function` is supported.
-    pub r#type: ChatCompletionToolType,
+    pub r#type: Option<ChatCompletionToolType>,
     /// The function that the model called.
     pub function: FunctionCall,
 }

--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -393,6 +393,7 @@ pub struct ChatCompletionMessageToolCall {
     /// The ID of the tool call.
     pub id: String,
     /// The type of the tool. Currently, only `function` is supported.
+    #[serde(default)]
     pub r#type: Option<ChatCompletionToolType>,
     /// The function that the model called.
     pub function: FunctionCall,

--- a/examples/tool-call-stream/src/main.rs
+++ b/examples/tool-call-stream/src/main.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let state = states_lock.entry(key).or_insert_with(|| {
                                 ChatCompletionMessageToolCall {
                                     id: tool_call_data.id.clone().unwrap_or_default(),
-                                    r#type: ChatCompletionToolType::Function,
+                                    r#type: Some(ChatCompletionToolType::Function),
                                     function: FunctionCall {
                                         name: tool_call_data
                                             .function


### PR DESCRIPTION
Do not convert errors to strings and return the whole errors instead.